### PR TITLE
added the initial calendar component for both teachers and volunteers

### DIFF
--- a/src/components/calendar/Calendar.js
+++ b/src/components/calendar/Calendar.js
@@ -1,0 +1,64 @@
+import React from "react";
+import FullCalendar from "@fullcalendar/react";
+import dayGridPlugin from "@fullcalendar/daygrid";
+import timeGridPlugin from "@fullcalendar/timegrid";
+import interactionPlugin from "@fullcalendar/interaction"; // needed for dayClick
+
+import "./main.scss";
+
+export default class Calendar extends React.Component {
+  calendarComponentRef = React.createRef();
+  state = {
+    calendarWeekends: true,
+    // instead of having calendar events in state, simply pass them in on props
+    calendarEvents: [
+      // initial event data
+      { title: "Event Now", start: new Date() },
+      { title: "Meeting with friends", start: new Date("2019-8-8") }
+    ]
+  };
+
+  render() {
+    return (
+      <div className="demo-app" style={{ marginTop: 100 }}>
+        <div className="demo-app-top">
+          <button onClick={this.toggleWeekends}>toggle weekends</button>&nbsp;
+          <button onClick={this.gotoPast}>go to a date in the past</button>
+          &nbsp; (also, click a date/time to add an event)
+        </div>
+        <div className="demo-app-calendar">
+          <FullCalendar
+            defaultView="dayGridMonth"
+            header={{
+              left: "prev,next today",
+              center: "title",
+              right: "dayGridMonth,timeGridWeek,timeGridDay,listWeek"
+            }}
+            plugins={[dayGridPlugin, timeGridPlugin, interactionPlugin]}
+            ref={this.calendarComponentRef}
+            weekends={this.state.calendarWeekends}
+            events={this.state.calendarEvents}
+            dateClick={this.handleDateClick}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  toggleWeekends = () => {
+    this.setState({
+      // update a property
+      calendarWeekends: !this.state.calendarWeekends
+    });
+  };
+
+  gotoPast = () => {
+    let calendarApi = this.calendarComponentRef.current.getApi();
+    calendarApi.gotoDate("2000-01-01"); // call a method on the Calendar object
+  };
+
+  handleDateClick = arg => {
+    console.log(arg);
+    // create a new meeting!
+  };
+}

--- a/src/components/calendar/main.scss
+++ b/src/components/calendar/main.scss
@@ -1,0 +1,17 @@
+@import "~@fullcalendar/core/main.css";
+@import "~@fullcalendar/daygrid/main.css";
+@import "~@fullcalendar/timegrid/main.css";
+
+.demo-app {
+  font-family: Arial, Helvetica Neue, Helvetica, sans-serif;
+  font-size: 14px;
+}
+
+.demo-app-top {
+  margin: 0 0 3em;
+}
+
+.demo-app-calendar {
+  margin: 0 auto;
+  max-width: 900px;
+}


### PR DESCRIPTION
# Description

This PR adds, but does not display, the FullCalendar component for our app. I created a seperate folder inside of components named "calendar" housing the SCSS and component files. I used this scss file simply because the FullCalendar demo does it this way. It still need some styling of course (looks fine as is, but to match the app when we get there). It also has some hard coded dates at the moment. Simply send in an array of scheduled meetings on props instead of using state the way that this component is currently, and we will be up and running!

## Checklist

Remove any items which are not applicable.

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
